### PR TITLE
fix: improve release workflow to check for existing tags and update versioning logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,46 +20,58 @@ jobs:
         with:
           node-version: 20
 
-      - name: Skip if tag already exists
-        id: check_tag
+      - run: npm ci
+
+      - name: Check if release needed
+        id: check_release
         run: |
-          TAG="v$(node -p "require('./package.json').version")"
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping release."
+          CURRENT_TAG="v$(node -p "require('./package.json').version")"
+          echo "CURRENT_TAG=$CURRENT_TAG" >> $GITHUB_OUTPUT
+
+          if git rev-parse "$CURRENT_TAG" >/dev/null 2>&1; then
+            echo "Tag $CURRENT_TAG already exists, skipping release."
             echo "SKIP=true" >> $GITHUB_OUTPUT
           else
             echo "SKIP=false" >> $GITHUB_OUTPUT
           fi
 
-      - run: npm ci
-
       - name: Configure Git for pushing
+        if: steps.check_release.outputs.SKIP == 'false'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/DorianABDS/alcasar-chrome-extension.git
 
-      - name: Run release
-        if: steps.check_tag.outputs.SKIP == 'false'
+      - name: Run release (creates new version and tag)
+        if: steps.check_release.outputs.SKIP == 'false'
         run: npm run release
 
+      - name: Get new version after release
+        if: steps.check_release.outputs.SKIP == 'false'
+        id: new_version
+        run: |
+          NEW_TAG="v$(node -p "require('./package.json').version")"
+          echo "NEW_TAG=$NEW_TAG" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_TAG"
+
       - name: Commit version bump and changelog
-        if: steps.check_tag.outputs.SKIP == 'false'
+        if: steps.check_release.outputs.SKIP == 'false'
         run: |
           git add package.json package-lock.json CHANGELOG.md manifest.json
-          git diff --cached --quiet || git commit -m "chore(release): bump version [skip ci]"
+          git diff --cached --quiet || git commit -m "chore(release): bump version to ${{ steps.new_version.outputs.NEW_TAG }} [skip ci]"
           git push origin main
 
       - name: Push tags
-        if: steps.check_tag.outputs.SKIP == 'false'
+        if: steps.check_release.outputs.SKIP == 'false'
         run: git push origin --tags
 
       - name: Create GitHub Release
-        if: steps.check_tag.outputs.SKIP == 'false'
+        if: steps.check_release.outputs.SKIP == 'false'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.check_tag.outputs.TAG }}
+          tag_name: ${{ steps.new_version.outputs.NEW_TAG }}
+          name: Release ${{ steps.new_version.outputs.NEW_TAG }}
           body_path: CHANGELOG.md
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release.yml` to improve version and tag management, streamline the release process, and enhance release note generation. The main changes focus on more reliable tag checking, better version bump handling, and improved release creation.

Release workflow improvements:

* Replaced the previous tag check step (`check_tag`) with a more comprehensive release check (`check_release`) that sets outputs for both the current tag and whether to skip the release. This makes the workflow more robust and clear.
* Ensured all subsequent release steps (Git configuration, release command, version bump commit, tag push, and GitHub release creation) are gated by the new `check_release` output, preventing unnecessary actions if the tag already exists.

Version and tagging enhancements:

* Added a step to capture the new version tag after running the release command, using the `new_version` step output to dynamically update commit messages and release information.
* Updated commit messages to include the specific new version tag, improving traceability in the repository history.

Release notes generation:

* Modified the GitHub Release step to use the new version tag and enabled automatic release notes generation for better documentation.